### PR TITLE
Move 6to5-core from dependencies to peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "6to5"
   ],
   "dependencies": {
-    "6to5-core": "^3.0.0",
     "gulp-util": "^3.0.0",
     "object-assign": "^2.0.0",
     "through2": "^0.6.1",
@@ -46,5 +45,8 @@
   "devDependencies": {
     "gulp-sourcemaps": "^1.1.1",
     "mocha": "*"
+  },
+  "peerDependencies": {
+    "6to5-core": ">=3.0.0"
   }
 }


### PR DESCRIPTION
This will result in the user choosing which version to install instead of this plugin, preventing the need to update this plugin on 6to5-core updates.

http://blog.nodejs.org/2013/02/07/peer-dependencies/