### PR TITLE
Fix readme's API name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ gulp.task('default', function () {
 
 ## API
 
-### 6to5(options)
+### to5(options)
 
 #### options
 


### PR DESCRIPTION
Small fix to clear up a little confusion in the readme.